### PR TITLE
ci: set up code coverage with Codecov

### DIFF
--- a/.github/workflows/build-test-and-lint.yml
+++ b/.github/workflows/build-test-and-lint.yml
@@ -30,3 +30,10 @@ jobs:
 
             - name: Check code formatting
               run: npm run prettify-check
+
+            - name: Upload coverage reports to Codecov
+              uses: codecov/codecov-action@v4.0.1
+              if: always()
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  slug: crowdsecurity/nodejs-cs-bouncer

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,8 @@
 import type { Config } from 'jest';
 
 const config: Config = {
+    collectCoverage: true,
+    coverageReporters: ['text', 'cobertura'],
     preset: 'ts-jest',
     testEnvironment: 'node',
     testPathIgnorePatterns: ['/node_modules/', '/dist/'],


### PR DESCRIPTION
We want to reach and keep a high level of code coverage.

To measure this code coverage, we will use [Codecov](https://codecov.io/) to receive our reports and allow us to display a coverage badge in the repository as well as keep track of changes regarding code coverage in each pull request.