### PR TITLE
feat: add minimal LAPI client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
                 "eslint-plugin-prefer-arrow-functions": "^3.3.2",
                 "eslint-plugin-simple-import-sort": "^12.0.0",
                 "jest": "^29.7.0",
+                "nock": "^14.0.0-beta.4",
                 "prettier": "^3.2.5",
                 "ts-jest": "^29.1.2",
                 "ts-node": "^10.9.2",
@@ -5207,6 +5208,12 @@
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
         },
+        "node_modules/json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+            "dev": true
+        },
         "node_modules/json5": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -5402,6 +5409,20 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
+        },
+        "node_modules/nock": {
+            "version": "14.0.0-beta.4",
+            "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.0-beta.4.tgz",
+            "integrity": "sha512-N9GIOnNFas/TtdCQpavpi6A6SyVVInkD/vrUCF2u51vlE2wSnqfPifVli6xSX8l6Lz/3sdSwPusE9n3KPDDh0g==",
+            "dev": true,
+            "dependencies": {
+                "debug": "^4.1.0",
+                "json-stringify-safe": "^5.0.1",
+                "propagate": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
         },
         "node_modules/node-int64": {
             "version": "0.4.0",
@@ -5911,6 +5932,15 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/propagate": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+            "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+            "dev": true,
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/pump": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "eslint-plugin-prefer-arrow-functions": "^3.3.2",
         "eslint-plugin-simple-import-sort": "^12.0.0",
         "jest": "^29.7.0",
+        "nock": "^14.0.0-beta.4",
         "prettier": "^3.2.5",
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",

--- a/src/lib/__tests__/lapi-client.test.ts
+++ b/src/lib/__tests__/lapi-client.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+import nock, { cleanAll as nockCleanAll } from 'nock';
+
+import LapiClient from 'src/lib/lapi-client';
+import { Decision } from 'src/lib/types';
+
+describe('LapiClient', () => {
+    const options = {
+        lapiUrl: 'http://example.com/api',
+        bouncerApiToken: 'test-api-key',
+        userAgent: 'test-user-agent',
+    };
+
+    const client = new LapiClient(options);
+
+    afterEach(() => {
+        nockCleanAll();
+    });
+
+    describe('constructor', () => {
+        it('should throw an error if `lapiUrl` does not start with http:// or https://', () => {
+            const invalidOptions = {
+                ...options,
+                lapiUrl: 'ftp://example.com/api',
+            };
+            expect(() => new LapiClient(invalidOptions)).toThrow(
+                '`lapiUrl` seems invalid. It should start with "http://" or "https://"',
+            );
+        });
+
+        it('should throw an error if `bouncerApiToken` is empty', () => {
+            const invalidOptions = { ...options, bouncerApiToken: '' };
+            expect(() => new LapiClient(invalidOptions)).toThrow(
+                '`bouncerApiToken` is required and must be non-empty',
+            );
+        });
+
+        it('should use default userAgent if not provided', () => {
+            const defaultUserAgentOptions = {
+                ...options,
+                userAgent: undefined,
+            };
+            const clientWithDefaultUserAgent = new LapiClient(
+                defaultUserAgentOptions,
+            );
+            expect(clientWithDefaultUserAgent).toBeDefined();
+            expect(
+                (clientWithDefaultUserAgent as unknown as { userAgent: string })
+                    .userAgent,
+            ).toBe('nodejs-cs-bouncer');
+        });
+    });
+
+    describe('getDecisionStream', () => {
+        it('should properly handle query parameters for the decision stream', async () => {
+            const nockScope = nock(options.lapiUrl)
+                .get('/v1/decisions/stream')
+                .query({
+                    startup: 'true',
+                    origins: 'cscli',
+                    scopes: 'ip,range',
+                    scenarios_containing: 'ssh,login',
+                    scenarios_not_containing: 'ignore',
+                })
+                .matchHeader('X-Api-Key', options.bouncerApiToken)
+                .matchHeader('User-Agent', options.userAgent)
+                .matchHeader('Content-Type', 'application/json')
+                .reply(
+                    200,
+                    { new: [], deleted: [] },
+                    {
+                        'Content-Type': 'application/json',
+                    },
+                );
+
+            const response = await client.getDecisionStream({
+                isFirstFetch: true,
+                origins: ['cscli'],
+                scopes: ['ip', 'range'],
+                scenariosContaining: ['ssh', 'login'],
+                scenariosNotContaining: ['ignore'],
+            });
+            expect(nockScope.isDone()).toBe(true);
+            expect(response).toEqual({ new: [], deleted: [] });
+        });
+
+        it('should throw an error with an explicit error message if the decision stream response is not ok', async () => {
+            nock(options.lapiUrl)
+                .get('/v1/decisions/stream')
+                .query(true)
+                .reply(500);
+
+            await expect(client.getDecisionStream()).rejects.toThrow(
+                'Call to v1/decisions/stream?startup=false failed',
+            );
+        });
+    });
+
+    describe('getDecisionsMatchingIp', () => {
+        const ip = '192.168.1.1';
+
+        const decisions: Decision[] = [
+            {
+                id: 1,
+                type: 'ban',
+                value: ip,
+                duration: '1h',
+                origin: 'cscli',
+                scope: 'ip',
+                simulated: false,
+                until: '2022-01-01T00:00:00Z',
+            },
+            {
+                id: 2,
+                type: 'captcha',
+                value: ip,
+                duration: '2h',
+                origin: 'cscli',
+                scope: 'ip',
+                simulated: false,
+                until: '2022-01-01T00:00:00Z',
+            },
+        ];
+
+        it('should return decisions matching a given IP', async () => {
+            const nockScope = nock(options.lapiUrl)
+                .get('/v1/decisions')
+                .query({ ip })
+                .matchHeader('X-Api-Key', options.bouncerApiToken)
+                .matchHeader('User-Agent', options.userAgent)
+                .matchHeader('Content-Type', 'application/json')
+                .reply(200, decisions, {
+                    'Content-Type': 'application/json',
+                });
+
+            const response = await client.getDecisionsMatchingIp(ip);
+            expect(nockScope.isDone()).toBe(true);
+            expect(response).toEqual(decisions);
+        });
+
+        it('should throw an error with an explicit error message if the response is not ok', async () => {
+            nock(options.lapiUrl).get(`/v1/decisions?ip=${ip}`).reply(500);
+
+            await expect(client.getDecisionsMatchingIp(ip)).rejects.toThrow(
+                'Call to v1/decisions?ip=192.168.1.1 failed',
+            );
+        });
+    });
+});

--- a/src/lib/lapi-client.ts
+++ b/src/lib/lapi-client.ts
@@ -1,0 +1,108 @@
+import { Decision, DecisionOrigin, DecisionScope } from 'src/lib/types';
+
+type LapiClientOptions = {
+    lapiUrl: string;
+    bouncerApiToken: string;
+    userAgent?: string;
+    timeout?: number;
+};
+
+class LapiClient {
+    private bouncerApiToken: string;
+    private lapiUrl: string;
+    private userAgent: string;
+
+    constructor(options: LapiClientOptions) {
+        const isValidUrl =
+            options.lapiUrl &&
+            (options.lapiUrl.startsWith('http://') ||
+                options.lapiUrl.startsWith('https://'));
+
+        if (!isValidUrl) {
+            throw new Error(
+                '`lapiUrl` seems invalid. It should start with "http://" or "https://"',
+            );
+        }
+
+        if (!options.bouncerApiToken) {
+            throw new Error(
+                '`bouncerApiToken` is required and must be non-empty',
+            );
+        }
+
+        this.lapiUrl = options.lapiUrl;
+        this.bouncerApiToken = options.bouncerApiToken;
+        this.userAgent = options.userAgent ?? 'nodejs-cs-bouncer';
+    }
+
+    private callLapiGetEndpoint = async <T>(path: string): Promise<T> => {
+        const response = await fetch(`${this.lapiUrl}/${path}`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Api-Key': this.bouncerApiToken,
+                'User-Agent': this.userAgent,
+            },
+        });
+
+        if (!response.ok) {
+            throw new Error(`Call to ${path} failed`);
+        }
+
+        return response.json() as T;
+    };
+
+    /**
+     * Retrieves a stream of decisions from the API.
+     * @param isFirstFetch - Indicates if it's the first fetch. If it is the first fetch, the LAPI will return the full list of decisions. If it's not, it will return only the changes
+     * that occurred since the last fetch (done by the same bouncer API token).
+     * @param origins - Filter decisions by their origin.
+     * @param scopes - Filter decisions by their scope.
+     * @param scenariosContaining - Filter decisions and returns **only** the ones associated with scenarios containing words passed in this argument.
+     * @param scenariosNotContaining - Filter decisions and returns **none** of the one associated with scenarios containing words passed in this argument.
+     */
+    public getDecisionStream = async ({
+        isFirstFetch = false,
+        origins,
+        scopes,
+        scenariosContaining,
+        scenariosNotContaining,
+    }: {
+        isFirstFetch?: boolean;
+        origins?: DecisionOrigin[];
+        scopes?: DecisionScope[];
+        scenariosContaining?: string[];
+        scenariosNotContaining?: string[];
+    } = {}): Promise<{ new: Decision[]; deleted: Decision[] }> => {
+        const params = new URLSearchParams({
+            startup: isFirstFetch.toString(),
+            ...(scopes ? { scopes: scopes.join(',') } : {}),
+            ...(origins ? { origins: origins.join(',') } : {}),
+            ...(scenariosContaining
+                ? { scenarios_containing: scenariosContaining.join(',') }
+                : {}),
+            ...(scenariosNotContaining
+                ? { scenarios_not_containing: scenariosNotContaining.join(',') }
+                : {}),
+        });
+
+        const fullUrl = `v1/decisions/stream?${params.toString()}`;
+
+        return this.callLapiGetEndpoint<{
+            new: Decision[];
+            deleted: Decision[];
+        }>(fullUrl);
+    };
+
+    /**
+     * Retrieves decisions that match the given IP address.
+     * @param ip - The IP address to match against the decisions.
+     */
+    public getDecisionsMatchingIp = async (ip: string): Promise<Decision[]> => {
+        const params = new URLSearchParams({ ip });
+        const fullUrl = `v1/decisions?${params.toString()}`;
+        return this.callLapiGetEndpoint<Decision[]>(fullUrl);
+    };
+}
+
+export default LapiClient;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,45 @@
+export type DecisionOrigin = 'cscli' | 'crowdsec';
+
+export type DecisionScope = 'ip' | 'range' | 'username';
+
+export type DecisionType = 'ban' | 'captcha' | 'custom';
+
+export type Decision = {
+    /**
+     * The external unique identifier of the decision. It should be used in GET requests.
+     */
+    id: number;
+    /**
+     * Whether the decision was done via the CLI or by the CrowdSec agent forwarding instructions from the web console.
+     */
+    origin: DecisionOrigin;
+    /**
+     * The remediation to apply to the IP.
+     */
+    type: DecisionType;
+    /**
+     * Whether the decision applies to an IP, a range of IPs or a username.
+     */
+    scope: DecisionScope;
+    /**
+     * The value of the decision scope: an IP, a range or a username.
+     */
+    value: string;
+    /**
+     * The duration of the decision in a string format.
+     *
+     * Examples:
+     * - "1h" for 1 hour
+     * - "3m" for 3 minutes
+     * - "45s" for 45 seconds
+     */
+    duration: string;
+    /**
+     * The date until the decision must be active.
+     */
+    until: string;
+    /**
+     * Whether the decision results from a scenario in simulation mode.
+     */
+    simulated: boolean;
+};


### PR DESCRIPTION
To apply remediations, we have to retrieve decisions from the Security Engine's LAPI.

This PR implements two ways of doing this:
- a `getDecisionsMatchingIp` method on the `LapiClient` to retrieve decisions for a single IP, useful for the **live mode**
- a `getDecisionStream` method on the `LapiClient` to retrieve decisions in **streaming mode**: each time a call is issued, the LAPI records the timestamp, and the next time the call is issued, only the changes that happened after that timestamp are returned. The LAPI has one "cursor" per bouncer API token, which means a bouncer API token **cannot be used on several bouncers** at the same time.